### PR TITLE
Add npm publish action for @cusedev/core

### DIFF
--- a/.github/workflows/npm-publish-core.yml
+++ b/.github/workflows/npm-publish-core.yml
@@ -1,0 +1,48 @@
+name: NPM Publish
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/core/**'
+
+jobs:
+  publish:
+    name: Publish to NPM
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        working-directory: packages/core
+        run: bun install
+
+      - name: Build
+        working-directory: packages/core
+        run: bun run build
+
+      - name: Bump patch version
+        working-directory: packages/core
+        run: bun x npm version patch --no-workspaces-update
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Publish to NPM
+        working-directory: packages/core
+        run: bunx npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automating the publishing of the `packages/core` package to NPM.