### PR TITLE
fix: network name in docker-compose template

### DIFF
--- a/packages/cli/templates/docker-compose.yml
+++ b/packages/cli/templates/docker-compose.yml
@@ -14,5 +14,5 @@ services:
 
 networks:
   network:
-    name: ${COMPOSE_PROJECT_NAME}-network
+    name: cuse-${COMPOSE_PROJECT_NAME}-network
     external: true


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose.yml` file. The change updates the network name to include a prefix for better identification.

* [`packages/cli/templates/docker-compose.yml`](diffhunk://#diff-829863fff95a58d5959d5d24f91e98b3f64167c3ab71c58b9be013806c4a76e9L17-R17): Changed the network name from `${COMPOSE_PROJECT_NAME}-network` to `cuse-${COMPOSE_PROJECT_NAME}-network` for better identification.